### PR TITLE
fix: check `workflow_run` within last day instead of last week, fixes #1

### DIFF
--- a/check-addons.sh
+++ b/check-addons.sh
@@ -67,7 +67,7 @@ fetch_repos_with_topic() {
 # Check the most recent scheduled workflow run
 check_recent_scheduled_run() {
   local current_date=$(${DATE} +%s)  # Current date in seconds since the Unix epoch
-  local one_week_ago=$(($current_date - 604800))  # One week ago in seconds since the Unix epoch
+  local one_day_ago=$(($current_date - 86400))  # One day ago in seconds since the Unix epoch
 
   mapfile -t repos < <(fetch_repos_with_topic)
   for repo in "${repos[@]}"; do
@@ -88,9 +88,9 @@ check_recent_scheduled_run() {
     local run_date=$(echo "$response" | jq -r '.workflow_runs[0].updated_at')
     local run_date_seconds=$(${DATE} -d "$run_date" +%s)  # Convert run date to seconds since the Unix epoch
 
-    # Check if the run date is within the last week
-    if [[ "${run_date_seconds}" -le "$one_week_ago" ]]; then
-        echo "ERROR: The most recent scheduled run for $repo was not within the last week."
+    # Check if the run date is within the last day
+    if [[ "${run_date_seconds}" -le "$one_day_ago" ]]; then
+        echo "ERROR: The most recent scheduled run for $repo was not within the last day."
         EXIT_CODE=2
     fi
 


### PR DESCRIPTION
## The Issue

- #1

## How This PR Solves The Issue

Changes a week to a day.

## Manual Testing Instructions

I haven't enabled the disabled workflows yet (so we can test this).

```
$ ./check-addons.sh --github-token=foobar --org=ddev
Organization: ddev
ddev/ddev-drupal-contrib: success (2025-06-24T08:46:25Z)
ddev/ddev-selenium-standalone-chrome: success (2025-06-24T08:47:56Z)
ddev/ddev-browsersync: success (2025-06-24T08:48:17Z)
ddev/ddev-redis: success (2025-06-24T08:44:34Z)
ddev/ddev-cron: success (2025-06-24T08:47:22Z)
ddev/ddev-phpmyadmin: success (2025-06-24T07:12:14Z)
ddev/ddev-solr: success (2025-06-24T08:47:05Z)
ddev/ddev-drupal-solr: success (2025-06-24T08:47:00Z)
ddev/ddev-elasticsearch: success (2025-06-24T08:45:17Z)
ddev/ddev-varnish: success (2025-06-24T08:42:52Z)
ddev/ddev-adminer: success (2025-06-24T08:39:45Z)
ddev/ddev-platformsh: success (2025-06-23T17:47:06Z)
ddev/ddev-rabbitmq: success (2025-06-24T08:48:01Z)
ERROR: The most recent scheduled run for ddev/ddev-opensearch was not within the last day.
ddev/ddev-opensearch: success (2025-06-21T07:12:12Z)
ERROR: The most recent scheduled run for ddev/ddev-mongo was not within the last day.
ddev/ddev-mongo: success (2025-06-21T08:55:14Z)
ddev/ddev-minio: success (2025-06-24T08:38:37Z)
ddev/ddev-redis-commander: success (2025-06-24T07:17:01Z)
ddev/ddev-typo3-solr: success (2025-06-24T08:43:17Z)
ddev/ddev-sqlsrv: success (2025-06-24T08:47:21Z)
ddev/ddev-memcached: success (2025-06-24T07:28:32Z)
ddev/ddev-ioncube: success (2025-06-24T08:42:16Z)
ERROR: The most recent scheduled run for ddev/ddev-ibexa-cloud was not within the last day.
ddev/ddev-ibexa-cloud: success (2025-06-21T08:49:51Z)
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

