### PR TITLE
Improve usability: repo links, token validation, rate limit handling, report

### DIFF
--- a/notify-addon-owners.sh
+++ b/notify-addon-owners.sh
@@ -25,7 +25,7 @@ DRY_RUN=false
 EXIT_CODE=0
 RATE_LIMIT_REMAINING=5000  # Default to 5000 requests/hour for core API
 SEARCH_RATE_LIMIT_REMAINING=30  # Default to 30 requests/minute for search API
-START_REPO=1  # Start from the nth repository (1-based index)
+START_REPO="1"  # Start from the nth repository (1-based index) or a repo name (owner/repo)
 
 # Loop through arguments and process them
 for arg in "$@"
@@ -63,7 +63,7 @@ do
         echo "                               issues, and commenting on issues in add-on repos"
         echo "  --org=ORG                GitHub organization to filter by (default: all)"
         echo "  --additional-github-repos=REPOS  Comma-separated list of additional repositories"
-        echo "  --start-repo=N           Start processing from the Nth repository (1-based index)"
+        echo "  --start-repo=N|OWNER/REPO  Start processing from the Nth repo (1-based) or named repo"
         echo "  --dry-run                Show what would be done without taking action"
         echo "  --help                   Show this help message"
         echo ""
@@ -71,6 +71,7 @@ do
         echo "  $0 --github-token=<token> --dry-run"
         echo "  $0 --github-token=<token> --org=ddev"
         echo "  $0 --github-token=<token> --start-repo=50 --dry-run"
+        echo "  $0 --github-token=<token> --start-repo=ddev/ddev-redis --dry-run"
         echo "  $0 --github-token=<token> --org=myusername --dry-run"
         exit 0
         ;;
@@ -629,9 +630,8 @@ handle_repo_with_tests() {
             issues=$(gh_api_safe "https://api.github.com/search/issues?q=repo:$repo+state:open+in:title+DDEV+Add-on+Test+Workflows+Suspended")
             local api_exit_code=$?
             if [[ "$api_exit_code" -eq 2 ]]; then
-                echo "  ⚠️  Rate limit reached while searching for issues. Skipping issue operations for $repo to avoid duplicates..."
-                existing_issue=""
-                search_failed=true
+                echo "  ⚠️  Rate limit reached while searching for issues."
+                return 2
             elif [[ "$api_exit_code" -ne 0 ]] || [[ "$issues" == "RATE_LIMIT_ERROR:"* ]] || ! echo "$issues" | jq -e . >/dev/null 2>&1; then
                 echo "  ⚠️  Failed to search for existing issues. Skipping issue operations for $repo to avoid duplicates..."
                 existing_issue=""
@@ -746,8 +746,8 @@ EOF
             issues=$(gh_api_safe "https://api.github.com/search/issues?q=repo:$repo+state:open+in:title+DDEV+Add-on+Test+Workflows+Suspended")
             local api_exit_code=$?
             if [[ "$api_exit_code" -eq 2 ]]; then
-                echo "  ⚠️  Rate limit reached while searching for open issues. Skipping issue search for $repo..."
-                open_issue=""
+                echo "  ⚠️  Rate limit reached while searching for open issues."
+                return 2
             elif [[ "$api_exit_code" -ne 0 ]] || [[ "$issues" == "RATE_LIMIT_ERROR:"* ]] || ! echo "$issues" | jq -e . >/dev/null 2>&1; then
                 open_issue=""
             else
@@ -774,25 +774,25 @@ handle_repo_without_tests() {
 }
 
 # Process a single repository with error handling
+# Returns 2 if rate limit was hit (caller should stop processing)
 process_repo() {
     local repo="$1"
-    
-    if has_test_workflows "$repo"; then
-        local workflows_exit_code=$?
-        if [[ "$workflows_exit_code" -eq 2 ]]; then
-            rate_limit_hit=true
-            echo "❌ RATE LIMIT [CORE: $RATE_LIMIT_REMAINING, SEARCH: $SEARCH_RATE_LIMIT_REMAINING]"
-            return 0  # Continue processing other repos
+
+    local workflows_exit_code=0
+    has_test_workflows "$repo" || workflows_exit_code=$?
+    if [[ "$workflows_exit_code" -eq 2 ]]; then
+        echo "❌ RATE LIMIT [CORE: $RATE_LIMIT_REMAINING, SEARCH: $SEARCH_RATE_LIMIT_REMAINING]"
+        return 2
+    fi
+
+    if [[ "$workflows_exit_code" -eq 0 ]]; then
+        local handle_exit_code=0
+        handle_repo_with_tests "$repo" || handle_exit_code=$?
+        if [[ "$handle_exit_code" -eq 2 ]]; then
+            return 2
         fi
-        handle_repo_with_tests "$repo"
         echo " [CORE: $RATE_LIMIT_REMAINING, SEARCH: $SEARCH_RATE_LIMIT_REMAINING]"
     else
-        local workflows_exit_code=$?
-        if [[ "$workflows_exit_code" -eq 2 ]]; then
-            rate_limit_hit=true
-            echo "❌ RATE LIMIT [CORE: $RATE_LIMIT_REMAINING, SEARCH: $SEARCH_RATE_LIMIT_REMAINING]"
-            return 0  # Continue processing other repos
-        fi
         handle_repo_without_tests "$repo"
         echo " [CORE: $RATE_LIMIT_REMAINING, SEARCH: $SEARCH_RATE_LIMIT_REMAINING]"
     fi
@@ -846,32 +846,62 @@ notify_about_disabled_workflows() {
   total_additional=$((${#filtered_additional_repos[@]} + ${#cli_repos[@]}))
   echo "Checking ${#unique_repos[@]} total repositories (${#topic_repos[@]} from topic '${topic}', ${total_additional} additional)"
   echo ""
-  
+
+  # Resolve --start-repo if it's a repo name (contains '/') instead of a number
+  if [[ "$START_REPO" == *"/"* ]]; then
+    local start_repo_name="$START_REPO"
+    START_REPO=""
+    for i in "${!unique_repos[@]}"; do
+      if [[ "${unique_repos[$i]}" == "$start_repo_name" ]]; then
+        START_REPO=$((i + 1))
+        break
+      fi
+    done
+    if [[ -z "$START_REPO" ]]; then
+      echo "ERROR: Repository '$start_repo_name' not found in the repo list."
+      echo "Available repositories:"
+      for i in "${!unique_repos[@]}"; do
+        echo "  $((i + 1)): ${unique_repos[$i]}"
+      done
+      return 1
+    fi
+    echo "Starting from repository $START_REPO ($start_repo_name)"
+    echo ""
+  fi
+
   rate_limit_hit=false
   for i in "${!unique_repos[@]}"; do
     local repo_num=$((i + 1))
     local repo="${unique_repos[$i]}"
-    
+
     # Skip if we haven't reached the starting repository
     if [[ $repo_num -lt $START_REPO ]]; then
         continue
     fi
-    
+
     echo -n "[$repo_num/$(( ${#unique_repos[@]} ))] Checking $repo (https://github.com/$repo)... "
-    
+
     # Wrap the repository processing in error handling
-    if ! process_repo "$repo"; then
+    local process_exit_code=0
+    process_repo "$repo" || process_exit_code=$?
+    if [[ "$process_exit_code" -eq 2 ]]; then
+        rate_limit_hit=true
+        local next_repo_num=$((repo_num))
+        echo ""
+        echo ""
+        echo "❌ Rate limit hit while processing repository $repo_num/${#unique_repos[@]} ($repo)."
+        echo "   Processed $((repo_num - START_REPO)) of $((${#unique_repos[@]} - START_REPO + 1)) repositories in this run."
+        echo ""
+        echo "   To resume from this repository, run:"
+        echo "   $0 --github-token=<token> --start-repo=${next_repo_num}"
+        echo "   or:"
+        echo "   $0 --github-token=<token> --start-repo=${repo}"
+        break
+    elif [[ "$process_exit_code" -ne 0 ]]; then
         echo "❌ ERROR processing $repo"
         continue
     fi
   done
-  
-  if [[ "$rate_limit_hit" == "true" ]]; then
-    echo ""
-    echo "⚠️  Rate limit was reached during processing."
-    echo "Some repositories may have been skipped due to API rate limiting."
-    echo "Consider running the script again later or using a personal access token with higher rate limits."
-  fi
   echo ""
 }
 

--- a/notify-addon-owners.sh
+++ b/notify-addon-owners.sh
@@ -82,8 +82,53 @@ do
     esac
 done
 
-if [ "${GITHUB_TOKEN}" = "" ]; then 
+if [ "${GITHUB_TOKEN}" = "" ]; then
     echo "ERROR: --github-token must be set"
+    exit 5
+fi
+
+# Validate token and check capabilities early
+echo -n "Validating GitHub token... "
+token_check_headers="/tmp/token_check_headers_$$"
+token_check_response=$(curl -s -D "$token_check_headers" -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/user" 2>&1)
+
+if [[ -f "$token_check_headers" ]]; then
+    http_status=$(head -1 "$token_check_headers" | grep -o '[0-9]\{3\}' | head -1)
+    if [[ "$http_status" == "401" ]]; then
+        echo "FAILED"
+        echo "ERROR: Invalid or expired GitHub token (HTTP 401 Unauthorized)"
+        rm -f "$token_check_headers"
+        exit 5
+    elif [[ "$http_status" == "403" ]]; then
+        echo "FAILED"
+        echo "ERROR: GitHub token is forbidden (HTTP 403). Check token permissions."
+        rm -f "$token_check_headers"
+        exit 5
+    fi
+
+    token_user=$(echo "$token_check_response" | jq -r '.login // "unknown"' 2>/dev/null)
+
+    # Check scopes for classic tokens (fine-grained tokens don't return x-oauth-scopes)
+    oauth_scopes=$(grep -i "^x-oauth-scopes:" "$token_check_headers" | cut -d':' -f2- | tr -d '\r\n' | xargs)
+    if [[ -n "$oauth_scopes" ]]; then
+        echo "OK (user: $token_user, scopes: $oauth_scopes)"
+        # Warn if missing required scopes
+        if ! echo "$oauth_scopes" | grep -qiE '(^|,)\s*repo\s*(,|$)'; then
+            if ! echo "$oauth_scopes" | grep -qi 'public_repo'; then
+                echo "WARNING: Token may lack required scopes. Need 'repo' or 'public_repo'."
+                echo "         Current scopes: $oauth_scopes"
+                echo "         The script will continue but may fail on some API calls."
+            fi
+        fi
+    else
+        echo "OK (user: $token_user, fine-grained token)"
+    fi
+    rm -f "$token_check_headers"
+else
+    echo "FAILED"
+    echo "ERROR: Could not connect to GitHub API"
     exit 5
 fi
 
@@ -366,7 +411,7 @@ fetch_repos_with_topic() {
   # First try GitHub search
   page=1
   while :; do
-    query="topic:$topic"
+    query="topic:$topic+archived:false"
     # only add org filter if org is specified and not "all"
     if [ "${org}" != "" ] && [ "${org}" != "all" ]; then query="${query}+org:$org"; fi
     

--- a/notify-addon-owners.sh
+++ b/notify-addon-owners.sh
@@ -22,10 +22,17 @@ GITHUB_TOKEN=""
 org="all"  # Default to check all organizations
 additional_github_repos=""
 DRY_RUN=false
+REPORT=false
 EXIT_CODE=0
 RATE_LIMIT_REMAINING=5000  # Default to 5000 requests/hour for core API
 SEARCH_RATE_LIMIT_REMAINING=30  # Default to 30 requests/minute for search API
 START_REPO="1"  # Start from the nth repository (1-based index) or a repo name (owner/repo)
+
+# Report tracking arrays
+REPORT_OK=()
+REPORT_DISABLED=()
+REPORT_NO_TESTS=()
+REPORT_ERRORS=()
 
 # Loop through arguments and process them
 for arg in "$@"
@@ -47,6 +54,10 @@ do
         DRY_RUN=true
         shift # Remove processed argument
         ;;
+        --report)
+        REPORT=true
+        shift # Remove processed argument
+        ;;
         --start-repo=*)
         START_REPO="${arg#*=}"
         shift # Remove processed argument
@@ -65,6 +76,7 @@ do
         echo "  --additional-github-repos=REPOS  Comma-separated list of additional repositories"
         echo "  --start-repo=N|OWNER/REPO  Start processing from the Nth repo (1-based) or named repo"
         echo "  --dry-run                Show what would be done without taking action"
+        echo "  --report                 Print a categorized summary report at the end"
         echo "  --help                   Show this help message"
         echo ""
         echo "Examples:"
@@ -610,6 +622,7 @@ handle_repo_with_tests() {
     local repo="$1"
     
     if has_disabled_test_workflows "$repo"; then
+        REPORT_DISABLED+=("$repo")
         echo "⚠️  DISABLED WORKFLOWS"
         
         if has_recently_closed_notification "$repo"; then
@@ -732,8 +745,9 @@ EOF
             fi
         fi
     else
+        REPORT_OK+=("$repo")
         echo "✅ OK"
-        
+
         # Close any open notification issues (only show if action taken)
         local open_issue
         open_issue=""
@@ -765,6 +779,7 @@ EOF
 # Handle repositories without test workflows
 handle_repo_without_tests() {
     local repo="$1"
+    REPORT_NO_TESTS+=("$repo")
     echo "⚠️  No test workflows found"
     
     # Only show this info in dry-run mode
@@ -898,6 +913,7 @@ notify_about_disabled_workflows() {
         echo "   $0 --github-token=<token> --start-repo=${repo}"
         break
     elif [[ "$process_exit_code" -ne 0 ]]; then
+        REPORT_ERRORS+=("$repo")
         echo "❌ ERROR processing $repo"
         continue
     fi
@@ -919,6 +935,44 @@ if [[ "$DRY_RUN" == "true" ]]; then
     echo "- Mode: DRY RUN (no actions taken)"
 else
     echo "- Mode: LIVE (actions may have been taken)"
+fi
+
+# Print categorized report if requested
+if [[ "$REPORT" == "true" ]]; then
+    echo ""
+    echo "======================================"
+    echo "  REPORT"
+    echo "======================================"
+    echo ""
+    echo "Tests OK: ${#REPORT_OK[@]}"
+    echo "Disabled workflows: ${#REPORT_DISABLED[@]}"
+    echo "No test workflows: ${#REPORT_NO_TESTS[@]}"
+    echo "Errors: ${#REPORT_ERRORS[@]}"
+
+    if [[ ${#REPORT_DISABLED[@]} -gt 0 ]]; then
+        echo ""
+        echo "--- Disabled workflows (${#REPORT_DISABLED[@]}) ---"
+        for repo in "${REPORT_DISABLED[@]}"; do
+            echo "  https://github.com/$repo"
+        done
+    fi
+
+    if [[ ${#REPORT_NO_TESTS[@]} -gt 0 ]]; then
+        echo ""
+        echo "--- No test workflows (${#REPORT_NO_TESTS[@]}) ---"
+        for repo in "${REPORT_NO_TESTS[@]}"; do
+            echo "  https://github.com/$repo"
+        done
+    fi
+
+    if [[ ${#REPORT_ERRORS[@]} -gt 0 ]]; then
+        echo ""
+        echo "--- Errors (${#REPORT_ERRORS[@]}) ---"
+        for repo in "${REPORT_ERRORS[@]}"; do
+            echo "  https://github.com/$repo"
+        done
+    fi
+    echo ""
 fi
 
 exit ${EXIT_CODE}

--- a/notify-addon-owners.sh
+++ b/notify-addon-owners.sh
@@ -4,6 +4,11 @@
 # and sends notifications to repository owners when workflows are suspended.
 # Uses GitHub issues for tracking notification history to avoid external state.
 # `./notify-addon-owners.sh --github-token=<token> --dry-run`
+#
+# GITHUB_TOKEN requirements:
+#   - Classic token: 'repo' scope (or 'public_repo' for public repos only)
+#   - Fine-grained token: "Actions" (read), "Issues" (read/write) permissions
+#   - The token must have access to the repositories being monitored.
 
 set -eu -o pipefail
 
@@ -50,7 +55,12 @@ do
         echo "Usage: $0 [OPTIONS]"
         echo ""
         echo "Options:"
-        echo "  --github-token=TOKEN     GitHub personal access token (required)"
+        echo "  --github-token=TOKEN     GitHub personal access token (required)."
+        echo "                           The token needs the following scopes:"
+        echo "                             - 'repo' (Full control of private repositories)"
+        echo "                               or 'public_repo' (Access public repositories)"
+        echo "                             - Required for: reading workflows, creating/closing"
+        echo "                               issues, and commenting on issues in add-on repos"
         echo "  --org=ORG                GitHub organization to filter by (default: all)"
         echo "  --additional-github-repos=REPOS  Comma-separated list of additional repositories"
         echo "  --start-repo=N           Start processing from the Nth repository (1-based index)"
@@ -802,7 +812,7 @@ notify_about_disabled_workflows() {
         continue
     fi
     
-    echo -n "[$repo_num/$(( ${#unique_repos[@]} ))] Checking $repo... "
+    echo -n "[$repo_num/$(( ${#unique_repos[@]} ))] Checking $repo (https://github.com/$repo)... "
     
     # Wrap the repository processing in error handling
     if ! process_repo "$repo"; then


### PR DESCRIPTION
## The Issue

- Usability improvements for `notify-addon-owners.sh`: missing repo links, undocumented token requirements, archived repos being checked, silent exit on rate limit, and no summary report option.

## How This PR Solves The Issue

- **Repo links in output**: Each processed repo now shows a clickable `https://github.com/owner/repo` URL for easy navigation.
- **GITHUB_TOKEN requirements documented**: The script header and `--help` output now explain the required token scopes (`repo` or `public_repo` for classic tokens, Actions read + Issues read/write for fine-grained tokens).
- **Early token validation**: On startup, the script calls `GET /user` to verify the token is valid, reports the authenticated user and scopes, and warns if required scopes are missing. Invalid tokens cause an immediate exit with a clear error.
- **Exclude archived repos**: The GitHub search query now includes `archived:false` so archived repositories are skipped during discovery.
- **Exit on rate limit with resume instructions**: Instead of silently dying (due to `set -e`) or skipping repos, the script now stops cleanly on rate limit and prints exactly how far it got and the command to resume, e.g. `--start-repo=50` or `--start-repo=owner/repo`.
- **`--start-repo` accepts repo names**: In addition to a numeric index, `--start-repo=owner/repo` is now supported, making it easy to copy/paste the resume command from a rate-limited run.
- **`--report` flag**: Prints a categorized summary at the end with counts (OK, disabled workflows, no test workflows, errors) and clickable URLs for all problem repositories. Works with `--dry-run`.

## Manual Testing Instructions

```bash
# Validate token checking (use a bad token)
./notify-addon-owners.sh --github-token=bad_token --dry-run

# Dry run with report
./notify-addon-owners.sh --github-token=<token> --dry-run --report

# Resume from a named repo
./notify-addon-owners.sh --github-token=<token> --start-repo=ddev/ddev-redis --dry-run --report
```

## Automated Testing Overview

No automated tests; this is a standalone operational script. Manual testing confirms token validation, rate-limit exit behavior, `--start-repo` by name, and `--report` output.

## Release/Deployment Notes

New CLI flags `--report` and repo-name support for `--start-repo` are additive and backward-compatible. No changes to the GitHub Actions workflow or deployment process.